### PR TITLE
Cancel superseded GitHub Actions runs for test and build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags: ['*']
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   build-image:
     name: "Build and push to Docker"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   integration-tests:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Add concurrency groups (matching monterecd) so a new push or PR update cancels any in-progress run instead of leaving multiple 45-minute jobs active.